### PR TITLE
Set score to 0 when generation changed

### DIFF
--- a/src/pages/Casual.jsx
+++ b/src/pages/Casual.jsx
@@ -40,6 +40,10 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    setScore(0);
+  }, [generations]);
+
   return (
     <div className="app">
       <div className="top">
@@ -55,8 +59,8 @@ function App() {
       </div>
       <div className="middle">
         <Guesser
-          pokedexState={pokedexState} // Pass the entire state
-          setPokedexState={setPokedexState} // Pass the setter
+          pokedexState={pokedexState}
+          setPokedexState={setPokedexState}
           selected={selected}
           setSelected={setSelected}
           generations={generations}


### PR DESCRIPTION
Whenever the generations selected state changes, setting the score to 0 prevents carrying over the score from a previous generation selection, ensuring the game starts fresh with the new generation configuration